### PR TITLE
[main] Run DAG in docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,45 @@
 # Stupid Flow
-A lightweight task flow simulator written in Go 
 
-To do
+Stupid Flow is a lightweight task flow simulator written in Go.
+
+## Features
 - YAML-based DAG config
 - Injected workloads: sleep, CPU burn, memory spike, fake I/O
 - CPU and Memory profiler (pprof)
-- Lightweight dockerized execution
+- Lightweight dockerized execution via `--docker-image`
+- CPU profile reports via `--report`
+
+## Usage
+Create a YAML file describing the tasks:
+
+```yaml
+tasks:
+  - id: first
+    type: sleep
+    duration: 1s
+  - id: second
+    type: cpu_burn
+    duration: 1s
+    depends_on:
+      - first
+```
+
+Run the simulator:
+
+```bash
+go run . --config path/to/dag.yaml
+```
+
+Run the entire DAG inside a Docker container (requires Docker):
+
+```bash
+go run . --config path/to/dag.yaml --docker-image alpine
+```
+
+Generate and show a CPU profile report:
+
+```bash
+go run . --config path/to/dag.yaml --docker-image alpine --report
+```
+
+Start the pprof server with `--pprof` and access profiles at `http://localhost:6060/debug/pprof/`.

--- a/config.go
+++ b/config.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"gopkg.in/yaml.v3"
+	"os"
+)
+
+// TaskType enumerates possible workload types.
+type TaskType string
+
+const (
+	TaskSleep       TaskType = "sleep"
+	TaskCPUBurn     TaskType = "cpu_burn"
+	TaskMemorySpike TaskType = "memory_spike"
+	TaskFakeIO      TaskType = "fake_io"
+)
+
+type Task struct {
+	ID        string   `yaml:"id"`
+	Type      TaskType `yaml:"type"`
+	Duration  string   `yaml:"duration,omitempty"`
+	SizeMB    int      `yaml:"size_mb,omitempty"`
+	Image     string   `yaml:"image,omitempty"`
+	DependsOn []string `yaml:"depends_on,omitempty"`
+}
+
+type Config struct {
+	Tasks []Task `yaml:"tasks"`
+}
+
+func loadConfig(path string) (Config, error) {
+	var cfg Config
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, err
+	}
+	err = yaml.Unmarshal(data, &cfg)
+	return cfg, err
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	yamlData := "tasks:\n- id: a\n  type: sleep\n  duration: 1s\n  image: busybox\n"
+	tmp := filepath.Join(t.TempDir(), "dag.yaml")
+	if err := os.WriteFile(tmp, []byte(yamlData), 0o600); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	cfg, err := loadConfig(tmp)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(cfg.Tasks) != 1 || cfg.Tasks[0].ID != "a" || cfg.Tasks[0].Image != "busybox" || cfg.Tasks[0].Type != TaskSleep {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}

--- a/dag.go
+++ b/dag.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+func runTask(ctx context.Context, t Task) error {
+	d, _ := time.ParseDuration(t.Duration)
+	switch t.Type {
+	case TaskSleep:
+		return runSleep(ctx, d)
+	case TaskCPUBurn:
+		return runCPUBurn(ctx, d)
+	case TaskMemorySpike:
+		return runMemorySpike(ctx, t.SizeMB, d)
+	case TaskFakeIO:
+		return runFakeIO(ctx, t.SizeMB)
+	default:
+		return errors.New("unknown task type")
+	}
+}
+
+func runDAGWithRunner(ctx context.Context, cfg Config, exec func(context.Context, Task) error) error {
+	remaining := make(map[string]Task)
+	for _, t := range cfg.Tasks {
+		remaining[t.ID] = t
+	}
+	completed := make(map[string]bool)
+
+	for len(remaining) > 0 {
+		progress := false
+		for id, t := range remaining {
+			ready := true
+			for _, dep := range t.DependsOn {
+				if !completed[dep] {
+					ready = false
+					break
+				}
+			}
+			if !ready {
+				continue
+			}
+			if err := exec(ctx, t); err != nil {
+				return err
+			}
+			completed[id] = true
+			delete(remaining, id)
+			progress = true
+		}
+		if !progress {
+			return errors.New("cyclic dependencies detected")
+		}
+	}
+	return nil
+}
+
+func runDAG(ctx context.Context, cfg Config) error {
+	return runDAGWithRunner(ctx, cfg, runTask)
+}

--- a/dag_test.go
+++ b/dag_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+type dagTestCase struct {
+	name    string
+	cfg     Config
+	wantErr bool
+}
+
+func TestRunDAG(t *testing.T) {
+	cases := []dagTestCase{
+		{
+			name: "simple dag",
+			cfg: Config{Tasks: []Task{
+				{ID: "a", Type: TaskSleep, Duration: "1ms"},
+				{ID: "b", Type: TaskCPUBurn, Duration: "1ms", DependsOn: []string{"a"}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "cycle",
+			cfg: Config{Tasks: []Task{
+				{ID: "a", Type: TaskSleep, Duration: "1ms", DependsOn: []string{"b"}},
+				{ID: "b", Type: TaskSleep, Duration: "1ms", DependsOn: []string{"a"}},
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := runDAG(context.Background(), tc.cfg)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunDAGWithRunner(t *testing.T) {
+	calls := []string{}
+	runner := func(ctx context.Context, t Task) error {
+		calls = append(calls, t.ID)
+		return nil
+	}
+	cfg := Config{Tasks: []Task{{ID: "a", Type: TaskSleep}, {ID: "b", Type: TaskSleep, DependsOn: []string{"a"}}}}
+	if err := runDAGWithRunner(context.Background(), cfg, runner); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(calls) != 2 || calls[0] != "a" || calls[1] != "b" {
+		t.Fatalf("unexpected order: %v", calls)
+	}
+}

--- a/docker_run.go
+++ b/docker_run.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func buildDockerArgs(cfgPath, binPath, outDir, image string, profile bool) []string {
+	args := []string{"run", "--rm", "-v", cfgPath + ":/app/dag.yaml", "-v", binPath + ":/app/stupidflow", "-v", outDir + ":/out", image, "/app/stupidflow", "--config", "/app/dag.yaml"}
+	if profile {
+		args = append(args, "--profile", "/out/profile.pb.gz")
+	}
+	return args
+}
+
+func runDAGInDocker(ctx context.Context, cfgPath, image string, profile bool) (string, error) {
+	binPath := filepath.Join(os.TempDir(), "stupidflow-bin")
+	if err := exec.CommandContext(ctx, "go", "build", "-o", binPath, ".").Run(); err != nil {
+		return "", err
+	}
+	outDir, err := os.MkdirTemp("", "stupidflow-out")
+	if err != nil {
+		return "", err
+	}
+	absCfg, err := filepath.Abs(cfgPath)
+	if err != nil {
+		return "", err
+	}
+	args := buildDockerArgs(absCfg, binPath, outDir, image, profile)
+	c := exec.CommandContext(ctx, "docker", args...)
+	if err := c.Run(); err != nil {
+		return "", err
+	}
+	if !profile {
+		return "", nil
+	}
+	prof := filepath.Join(outDir, "profile.pb.gz")
+	out, err := exec.CommandContext(ctx, "go", "tool", "pprof", "-top", "-nodecount=5", binPath, prof).CombinedOutput()
+	return string(out), err
+}

--- a/docker_run_test.go
+++ b/docker_run_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestBuildDockerArgs(t *testing.T) {
+	args := buildDockerArgs("/cfg.yaml", "/bin/app", "/out", "alpine", true)
+	want := []string{"run", "--rm", "-v", "/cfg.yaml:/app/dag.yaml", "-v", "/bin/app:/app/stupidflow", "-v", "/out:/out", "alpine", "/app/stupidflow", "--config", "/app/dag.yaml", "--profile", "/out/profile.pb.gz"}
+	if len(args) != len(want) {
+		t.Fatalf("unexpected len %d", len(args))
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("want %s got %s at %d", want[i], args[i], i)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/stupidflow
+
+go 1.24.3
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+)
+
+func main() {
+	cfgPath := flag.String("config", "dag.yaml", "path to DAG config")
+	enablePprof := flag.Bool("pprof", false, "enable pprof server")
+	dockerImage := flag.String("docker-image", "", "run tasks in docker using this image")
+	report := flag.Bool("report", false, "show CPU profile report")
+	flag.Parse()
+
+	if *enablePprof {
+		go func() {
+			log.Println(http.ListenAndServe("localhost:6060", nil))
+		}()
+	}
+
+	cfg, err := loadConfig(*cfgPath)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	ctx := context.Background()
+	if *dockerImage != "" {
+		out, err := runDAGInDocker(ctx, *cfgPath, *dockerImage, *report)
+		if err != nil {
+			log.Fatalf("run DAG: %v", err)
+		}
+		if *report {
+			fmt.Print(out)
+		}
+	} else if *report {
+		out, err := runDAGProfile(ctx, cfg)
+		if err != nil {
+			log.Fatalf("run DAG: %v", err)
+		}
+		fmt.Print(out)
+	} else {
+		if err := runDAG(ctx, cfg); err != nil {
+			log.Fatalf("run DAG: %v", err)
+		}
+	}
+
+	os.Exit(0)
+}

--- a/profile.go
+++ b/profile.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime/pprof"
+)
+
+func runDAGProfile(ctx context.Context, cfg Config) (string, error) {
+	tmp, err := os.CreateTemp("", "stupidflow-prof")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmp.Name())
+	if err := pprof.StartCPUProfile(tmp); err != nil {
+		return "", err
+	}
+	err = runDAG(ctx, cfg)
+	pprof.StopCPUProfile()
+	if err != nil {
+		return "", err
+	}
+	out, err := exec.CommandContext(ctx, "go", "tool", "pprof", "-top", "-nodecount=5", os.Args[0], tmp.Name()).CombinedOutput()
+	return string(out), err
+}

--- a/workloads.go
+++ b/workloads.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"os"
+	"time"
+)
+
+func runSleep(ctx context.Context, d time.Duration) error {
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func runCPUBurn(ctx context.Context, d time.Duration) error {
+	end := time.Now().Add(d)
+	for time.Now().Before(end) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+	return nil
+}
+
+func runMemorySpike(ctx context.Context, sizeMB int, d time.Duration) error {
+	b := make([]byte, sizeMB*1024*1024)
+	for i := range b {
+		b[i] = byte(i)
+	}
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func runFakeIO(ctx context.Context, sizeMB int) error {
+	f, err := os.CreateTemp("", "stupidflow")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	data := make([]byte, 1024*1024)
+	for i := 0; i < sizeMB; i++ {
+		if _, err := rand.Read(data); err != nil {
+			return err
+		}
+		if _, err := f.Write(data); err != nil {
+			return err
+		}
+	}
+	return f.Close()
+}


### PR DESCRIPTION
## Summary
- remove per-task docker logic
- run entire DAG in a container with `--docker-image`
- add optional CPU profile reporting via `--report`
- document docker execution and report flag in README
- add basic tests for docker argument builder

## Testing
- `go vet ./...`
- `go test ./...`