### PR TITLE
[core] Add BaseNode validation coverage

### DIFF
--- a/core/basenode.go
+++ b/core/basenode.go
@@ -1,0 +1,37 @@
+package core
+
+import (
+	"errors"
+	"strings"
+)
+
+// BaseNode contains the common metadata required by all nodes.
+type BaseNode struct {
+	ID     string         `json:"id"`
+	Config map[string]any `json:"config,omitempty"`
+}
+
+var (
+	errNilBaseNode   = errors.New("base node must not be nil")
+	errEmptyNodeID   = errors.New("node id must not be empty")
+	errNilNodeConfig = errors.New("node config must not be nil")
+)
+
+// Validate returns a slice of validation errors for the base node.
+func (n *BaseNode) Validate() []error {
+	if n == nil {
+		return []error{errNilBaseNode}
+	}
+
+	errs := make([]error, 0, 2)
+
+	if strings.TrimSpace(n.ID) == "" {
+		errs = append(errs, errEmptyNodeID)
+	}
+
+	if n.Config == nil {
+		errs = append(errs, errNilNodeConfig)
+	}
+
+	return errs
+}

--- a/core/basenode_test.go
+++ b/core/basenode_test.go
@@ -1,0 +1,60 @@
+package core
+
+import "testing"
+
+func TestBaseNodeValidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		node    *BaseNode
+		wantLen int
+	}{
+		{
+			name: "valid node",
+			node: &BaseNode{
+				ID:     "start",
+				Config: map[string]any{},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "missing id",
+			node: &BaseNode{
+				ID:     "",
+				Config: map[string]any{},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "nil config",
+			node: &BaseNode{
+				ID: "task",
+			},
+			wantLen: 1,
+		},
+		{
+			name:    "missing id and config",
+			node:    &BaseNode{},
+			wantLen: 2,
+		},
+		{
+			name:    "nil base node",
+			node:    nil,
+			wantLen: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.node.Validate()
+			if len(err) != tc.wantLen {
+				t.Fatalf("Validate() error count = %d, want %d", len(err), tc.wantLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a reusable BaseNode struct with validation for missing identifiers and config
- cover BaseNode.Validate with table-driven tests for valid and invalid inputs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d75ed2fb5483339cc7e12be1065865