### PR TITLE
[main] Add gh CLI instructions to contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,10 @@ Title format: [<package_name>] <Short Description>
 
 For example:
 [auth] Add JWT token renewal logic
+
+## Working with the `gh` CLI
+- Always authenticate with `gh auth login` before running any other commands.
+- Use `gh pr checkout <number>` to review pull requests locally.
+- Run `gh pr create --fill` to open new pull requests using the prepared commit information.
+- Use `gh issue list` and `gh issue view <number>` to triage or review existing issues.
+- When in doubt about available commands, run `gh help` or `gh <command> --help` for detailed guidance.


### PR DESCRIPTION
## Summary
- document recommended gh CLI authentication and workflow commands in AGENTS.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db6e42b6b48333a8f052253a043a51